### PR TITLE
Fix typo that makes data get a nibble out of kilter when sending.

### DIFF
--- a/src/MKRWAN_v2.h
+++ b/src/MKRWAN_v2.h
@@ -781,7 +781,7 @@ private:
     String msg_buf;
     // Convert buff to hex
     for (size_t i=0; i<len; i++) {
-      if (buff[i] < 10) {
+      if (buff[i] < 16) {
         msg_buf += "0";
       }
       msg_buf += String(buff[i], HEX);


### PR DESCRIPTION
The check for prefixing a leading zero is base 10, but the string is hex, so it should be base 16. This causes a nibble to be dropped when the value of the byte to be sent is between 0x0A and 0x0F, which causes and invalid and/or corrupted packet.