### PR TITLE
architectures=samd needs mbed for examples to show up

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Support library for MKR WAN 1300/1310 - firmware 1.3.1
 paragraph=Provides APIs to communicate with LoRa and LoraWAN networks
 category=Communication
 url=http://github.com/arduino-libraries/MKRWAN_v2
-architectures=samd
+architectures=samd,mbed


### PR DESCRIPTION
Include mbed in the architestures so that the examples will show for the PortentaH7 LoRaWan Vision Shield.