### PR TITLE
Fix regression report-size-deltas after updating upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -37,18 +37,22 @@ jobs:
             platforms: |
               - name: arduino:mbed_portenta
             fw-update: false
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7-target_core-cm4
           - fqbn: arduino:mbed_portenta:envie_m7
             platforms: |
               - name: arduino:mbed_portenta
             fw-update: true
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7
           - fqbn: arduino:samd:mkrwan1300
             platforms: |
               - name: arduino:samd
             fw-update: true
+            artifact-name-suffix: arduino-mbed_portenta-wan1300
           - fqbn: arduino:samd:mkrwan1310
             platforms: |
               - name: arduino:samd
             fw-update: true
+            artifact-name-suffix: arduino-mbed_portenta-wan1310
 
         # Make board type-specific customizations to the matrix jobs.
         include:
@@ -90,4 +94,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .