### PR TITLE
Change author/maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=MKRWAN_v2
 version=1.3.2
-author=Arduino <support@arduino.cc>
-maintainer=Arduino <support@arduino.cc>
+author=Arduino <info@arduino.cc>
+maintainer=Arduino <info@arduino.cc>
 sentence=Support library for MKR WAN 1300/1310 - firmware 1.3.1
 paragraph=Provides APIs to communicate with LoRa and LoraWAN networks
 category=Communication


### PR DESCRIPTION
Author/Maintainer is changed from `Arduino <support@arduino.cc>` to `Arduino <info@arduino.cc>` within the `library.properties` file. 